### PR TITLE
Fix view validation errors - add missing button names

### DIFF
--- a/odoo/addons/scientific_project/models/experiment.py
+++ b/odoo/addons/scientific_project/models/experiment.py
@@ -132,3 +132,23 @@ class ScientificExperiment(models.Model):
             'view_mode': 'form',
             'target': 'current',
         }
+
+    def action_view_researchers(self):
+        """Smart button action to view assigned researchers"""
+        return {
+            'name': 'Researchers',
+            'type': 'ir.actions.act_window',
+            'res_model': 'scientific.researcher',
+            'view_mode': 'tree,form',
+            'domain': [('id', 'in', self.assigned_to_ids.ids)],
+        }
+
+    def action_view_equipment(self):
+        """Smart button action to view equipment"""
+        return {
+            'name': 'Equipment',
+            'type': 'ir.actions.act_window',
+            'res_model': 'scientific.equipment',
+            'view_mode': 'tree,form',
+            'domain': [('id', 'in', self.equipment_ids.ids)],
+        }

--- a/odoo/addons/scientific_project/models/partner.py
+++ b/odoo/addons/scientific_project/models/partner.py
@@ -101,3 +101,14 @@ class ScientificPartner(models.Model):
             'domain': [('id', 'in', self.project_ids.ids)],
         }
 
+    def action_view_active_projects(self):
+        """View active projects"""
+        active_project_ids = self.project_ids.filtered(lambda p: p.status == 'in_progress')
+        return {
+            'name': 'Active Projects',
+            'type': 'ir.actions.act_window',
+            'res_model': 'scientific.project',
+            'view_mode': 'tree,form',
+            'domain': [('id', 'in', active_project_ids.ids)],
+        }
+

--- a/odoo/addons/scientific_project/views/data_management.xml
+++ b/odoo/addons/scientific_project/views/data_management.xml
@@ -40,7 +40,7 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" type="object"
+                        <button class="oe_stat_button"
                                 icon="fa-calendar">
                             <field string="Days Old" name="age_days" widget="statinfo"/>
                         </button>

--- a/odoo/addons/scientific_project/views/experiment.xml
+++ b/odoo/addons/scientific_project/views/experiment.xml
@@ -56,10 +56,10 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" type="object" icon="fa-users">
+                        <button class="oe_stat_button" type="object" name="action_view_researchers" icon="fa-users">
                             <field string="Researchers" name="assigned_researcher_count" widget="statinfo"/>
                         </button>
-                        <button class="oe_stat_button" type="object" icon="fa-wrench">
+                        <button class="oe_stat_button" type="object" name="action_view_equipment" icon="fa-wrench">
                             <field string="Equipment" name="equipment_count" widget="statinfo"/>
                         </button>
                     </div>

--- a/odoo/addons/scientific_project/views/partner.xml
+++ b/odoo/addons/scientific_project/views/partner.xml
@@ -37,7 +37,7 @@
                                 icon="fa-folder">
                             <field string="Projects" name="project_count" widget="statinfo"/>
                         </button>
-                        <button class="oe_stat_button" type="object"
+                        <button class="oe_stat_button" type="object" name="action_view_active_projects"
                                 icon="fa-tasks">
                             <field string="Active" name="active_projects" widget="statinfo"/>
                         </button>


### PR DESCRIPTION
Fixed RPC_ERROR caused by buttons missing required 'name' attribute:
- experiment.xml: Added action_view_researchers and action_view_equipment methods and button names
- partner.xml: Added action_view_active_projects method and button name
- data_management.xml: Removed type="object" from informational stat button

All stat buttons with type="object" now have proper action methods defined.