### PR TITLE
Fix field reference error in experiment view

### DIFF
--- a/odoo/addons/scientific_project/views/experiment.xml
+++ b/odoo/addons/scientific_project/views/experiment.xml
@@ -108,7 +108,7 @@
                             <field name="equipment_ids">
                                 <tree>
                                     <field name="name"/>
-                                    <field name="type"/>
+                                    <field name="equipment_type"/>
                                     <field name="status"/>
                                     <field name="location"/>
                                 </tree>


### PR DESCRIPTION
Fixed incorrect field reference in experiment.xml where 'type' was used instead of 'equipment_type' for the scientific.equipment model.

The error occurred in the Equipment tab's embedded tree view (line 111). The scientific.equipment model defines the field as 'equipment_type' (models/equipment.py:11), not 'type'.

Changes:
- experiment.xml:111: Changed 'type' to 'equipment_type'

Related models checked for similar issues:
- scientific.reagent: correctly uses 'type' field (exists in model)
- scientific.researcher: correctly uses 'type' field (exists in model)
- equipment.xml: already correctly uses 'equipment_type'