### PR TITLE
Fix missing external ID in publication view

### DIFF
--- a/odoo/addons/scientific_project/views/publication.xml
+++ b/odoo/addons/scientific_project/views/publication.xml
@@ -43,9 +43,8 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" type="object" name="%(action_scientific_experiment)d"
-                                icon="fa-flask" context="{'search_default_project_id': active_id}">
-                            <field string="Experiments" name="experiment_ids" widget="statinfo"/>
+                        <button class="oe_stat_button" type="object" name="action_view_experiments" icon="fa-flask">
+                            <field string="Experiments" name="experiment_count" widget="statinfo"/>
                         </button>
                     </div>
                     <group>


### PR DESCRIPTION
- Add experiment_count computed field to publication model
- Add action_view_experiments method to handle smart button click
- Replace invalid external ID reference %(action_scientific_experiment)d with proper method call
- Update button to use experiment_count instead of experiment_ids for statinfo widget

This fixes the RPC_ERROR caused by referencing a non-existent external ID