### PR TITLE
Fix missing external IDs across multiple views and models

### DIFF
--- a/odoo/addons/scientific_project/models/researcher.py
+++ b/odoo/addons/scientific_project/models/researcher.py
@@ -123,7 +123,7 @@ class ScientificResearcher(models.Model):
 
             try:
                 # Determine user group based on researcher type
-                group_ref = 'scientific_project.group_scientific_user'
+                group_ref = 'scientific_project.group_scientific_researcher'
                 if researcher.type == 'professor':
                     group_ref = 'scientific_project.group_scientific_manager'
 

--- a/odoo/addons/scientific_project/views/data_management.xml
+++ b/odoo/addons/scientific_project/views/data_management.xml
@@ -197,7 +197,7 @@
     <!-- Menu Item -->
     <menuitem id="menu_scientific_data_management"
               name="Data Management"
-              parent="menu_scientific_project_root"
+              parent="scientific_root"
               action="action_scientific_data_management"
               sequence="45"/>
 </odoo>

--- a/odoo/addons/scientific_project/views/experiment.xml
+++ b/odoo/addons/scientific_project/views/experiment.xml
@@ -144,6 +144,19 @@
         </field>
     </record>
 
+    <!-- Action for experiments (alternative naming for consistency) -->
+    <record id="action_scientific_experiment" model="ir.actions.act_window">
+        <field name="name">Experiments</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">scientific.experiment</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new experiment
+            </p>
+        </field>
+    </record>
+
 
 
     <!-- Menu item for experiments -->

--- a/odoo/addons/scientific_project/views/partner.xml
+++ b/odoo/addons/scientific_project/views/partner.xml
@@ -207,7 +207,7 @@
     <!-- Menu Item -->
     <menuitem id="menu_scientific_partner"
               name="Partners"
-              parent="menu_scientific_project_root"
+              parent="scientific_root"
               action="action_scientific_partner"
               sequence="50"/>
 </odoo>

--- a/odoo/addons/scientific_project/views/publication.xml
+++ b/odoo/addons/scientific_project/views/publication.xml
@@ -187,7 +187,7 @@
     <!-- Menu Item -->
     <menuitem id="menu_scientific_publication"
               name="Publications"
-              parent="menu_scientific_project_root"
+              parent="scientific_root"
               action="action_scientific_publication"
               sequence="40"/>
 </odoo>


### PR DESCRIPTION
This commit resolves several missing external ID references that were causing RPC_ERROR exceptions during module installation and usage:

1. Added missing action_scientific_experiment to experiment.xml
   - Provides consistent naming convention with other action_scientific_* actions
   - Fixes references that expected this external ID to exist

2. Fixed incorrect security group reference in researcher.py
   - Changed 'group_scientific_user' (non-existent) to 'group_scientific_researcher'
   - Ensures proper user group assignment when creating researcher accounts

3. Fixed incorrect menu parent references in multiple views:
   - publication.xml: Changed menu_scientific_project_root to scientific_root
   - data_management.xml: Changed menu_scientific_project_root to scientific_root
   - partner.xml: Changed menu_scientific_project_root to scientific_root
   - Ensures menu items are properly displayed in the navigation hierarchy

These fixes prevent "External ID not found in the system" errors and ensure proper module functionality.