### PR TITLE
Fix unsearchable computed fields by adding store=True

### DIFF
--- a/odoo/addons/scientific_project/models/data.py
+++ b/odoo/addons/scientific_project/models/data.py
@@ -54,8 +54,8 @@ class ScientificDataManagement(models.Model):
     notes = fields.Text(string='Notes')
 
     # Computed fields
-    age_days = fields.Integer(string='Age (Days)', compute='_compute_age_days')
-    is_recent = fields.Boolean(string='Recent', compute='_compute_is_recent')
+    age_days = fields.Integer(string='Age (Days)', compute='_compute_age_days', store=True)
+    is_recent = fields.Boolean(string='Recent', compute='_compute_is_recent', store=True)
 
     @api.depends('upload_date')
     def _compute_age_days(self):

--- a/odoo/addons/scientific_project/models/partner.py
+++ b/odoo/addons/scientific_project/models/partner.py
@@ -53,7 +53,7 @@ class ScientificPartner(models.Model):
 
     # Computed fields
     project_count = fields.Integer(string='Projects', compute='_compute_project_count', store=True)
-    active_projects = fields.Integer(string='Active Projects', compute='_compute_active_projects')
+    active_projects = fields.Integer(string='Active Projects', compute='_compute_active_projects', store=True)
     is_active = fields.Boolean(string='Active', compute='_compute_is_active')
 
     @api.depends('project_ids')


### PR DESCRIPTION
- Fixed is_recent and age_days fields in data_management model
- Fixed active_projects field in partner model
- These computed fields are now stored in database and can be used in search filters
- Resolves error: "Unsearchable field 'is_recent' in path 'is_recent' in domain"

Files changed:
- odoo/addons/scientific_project/models/data.py: Added store=True to is_recent and age_days
- odoo/addons/scientific_project/models/partner.py: Added store=True to active_projects