### PR TITLE
Fix invitation error and update role selection to scientific roles

### DIFF
--- a/odoo/addons/scientific_project/wizards/researcher_invitation.py
+++ b/odoo/addons/scientific_project/wizards/researcher_invitation.py
@@ -32,9 +32,11 @@ class ResearcherInvitationWizard(models.TransientModel):
         help="Valid email address for sending the invitation"
     )
     type = fields.Selection([
-        ('student', 'Student'),
-        ('researcher', 'Researcher'),
-        ('professor', 'Professor')
+        ('manager', 'Scientific Project Manager'),
+        ('pi', 'Principal Investigator'),
+        ('researcher', 'Scientific Project User'),
+        ('technician', 'Lab Technician'),
+        ('viewer', 'Scientific Project Viewer')
     ],
         string='Role',
         required=True,


### PR DESCRIPTION
- Fix 're' is not defined error by adding missing imports (re, base64, imghdr, string, secrets) to researcher.py
- Update role selection in invitation wizard to use scientific-specific roles:
  * Scientific Project Manager
  * Principal Investigator
  * Scientific Project User
  * Lab Technician
  * Scientific Project Viewer
- Update role-to-group mapping to assign correct security groups
- Remove duplicate email validation method in researcher model

This resolves the invitation sending error and provides more relevant role options for scientific project management.