### PR TITLE
Fix scientific invitation access error and improve form UI

### DIFF
--- a/odoo/addons/scientific_project/views/researcher_invitation_wizard.xml
+++ b/odoo/addons/scientific_project/views/researcher_invitation_wizard.xml
@@ -7,37 +7,72 @@
         <field name="arch" type="xml">
             <form string="Invite Researcher">
                 <sheet>
-                    <div class="oe_title">
-                        <h1>Invite New Researcher</h1>
+                    <div class="oe_title mb-3">
+                        <h1 class="mb-2">
+                            <i class="fa fa-user-plus text-primary me-2"/>
+                            Invite New Researcher
+                        </h1>
                         <p class="text-muted">
                             Send an invitation to a new researcher to join your team.
                             A user account will be created automatically and credentials will be sent via email.
                         </p>
                     </div>
-                    <group>
+
+                    <group string="Basic Information" class="mt-3">
                         <group>
-                            <field name="name" placeholder="e.g., Dr. Jane Smith"/>
-                            <field name="email" placeholder="jane.smith@university.edu" widget="email"/>
-                            <field name="type" widget="radio" options="{'horizontal': true}"/>
+                            <label for="name" string="Full Name" class="fw-bold"/>
+                            <field name="name" placeholder="e.g., Dr. Jane Smith" class="o_field_highlight"/>
+
+                            <label for="email" string="Email Address" class="fw-bold"/>
+                            <field name="email" placeholder="jane.smith@university.edu" widget="email" class="o_field_highlight"/>
                         </group>
                         <group>
+                            <label for="title" string="Academic Title"/>
                             <field name="title" placeholder="e.g., Dr., Prof., MSc."/>
+
+                            <label for="affiliation" string="Institution"/>
                             <field name="affiliation" placeholder="University or Institution"/>
-                            <field name="specialization" placeholder="e.g., Molecular Biology"/>
                         </group>
                     </group>
-                    <group>
-                        <field name="message" placeholder="Add a personal message to include in the invitation email (optional)..." nolabel="1"/>
+
+                    <group string="Role Assignment" class="mt-3">
+                        <field name="type" widget="radio" options="{'horizontal': false}" class="o_field_widget"/>
                     </group>
-                    <div class="alert alert-info" role="alert">
-                        <i class="fa fa-info-circle"/>
-                        <strong>Note:</strong> Only administrators and managers can send invitations to all roles.
-                        The invited researcher will receive an email with instructions to set their password.
+
+                    <group string="Additional Information" class="mt-3">
+                        <field name="specialization" placeholder="e.g., Molecular Biology, Genetics, Biochemistry"/>
+                    </group>
+
+                    <group string="Personal Message (Optional)" class="mt-3">
+                        <field name="message"
+                               placeholder="Add a personal welcome message to include in the invitation email..."
+                               nolabel="1"
+                               class="o_field_text"/>
+                    </group>
+
+                    <div class="alert alert-info mt-3" role="alert">
+                        <div class="d-flex align-items-start">
+                            <i class="fa fa-info-circle me-2 mt-1"/>
+                            <div>
+                                <strong>Important Information:</strong>
+                                <ul class="mb-0 mt-2">
+                                    <li>The invited researcher will receive an email with a password reset link</li>
+                                    <li>They can set their own password upon first login</li>
+                                    <li>Access permissions will be assigned based on the selected role</li>
+                                    <li>Only administrators and managers can send invitations</li>
+                                </ul>
+                            </div>
+                        </div>
                     </div>
                 </sheet>
                 <footer>
-                    <button name="action_send_invitation" string="Send Invitation" type="object" class="btn-primary"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    <button name="action_send_invitation"
+                            string="Send Invitation"
+                            type="object"
+                            class="btn-primary"/>
+                    <button string="Cancel"
+                            class="btn-secondary"
+                            special="cancel"/>
                 </footer>
             </form>
         </field>

--- a/odoo/addons/scientific_project/wizards/researcher_invitation.py
+++ b/odoo/addons/scientific_project/wizards/researcher_invitation.py
@@ -187,7 +187,7 @@ class ResearcherInvitationWizard(models.TransientModel):
         if not researcher.user_id:
             return
 
-        # Get email template
+        # Get email template with sudo to ensure access
         template = self.env.ref('scientific_project.email_template_researcher_invitation',
                                raise_if_not_found=False)
 
@@ -201,8 +201,8 @@ class ResearcherInvitationWizard(models.TransientModel):
                 'login_url': self.env['ir.config_parameter'].sudo().get_param('web.base.url'),
             }
 
-            # Send email
-            template.with_context(ctx).send_mail(
+            # Send email with sudo to ensure proper access rights
+            template.sudo().with_context(ctx).send_mail(
                 researcher.id,
                 force_send=True,
                 email_values={'email_to': researcher.email}


### PR DESCRIPTION
Fixed the "Record does not exist or has been deleted" error that occurred when sending scientific invitations. The issue was caused by insufficient access rights when sending the invitation email template.

Changes:
- Added sudo() to email template send operation to ensure proper access
- Improved invitation form view with better organization and visual hierarchy
- Added icon to form title and grouped fields logically
- Enhanced info section with bulleted list of important details
- Changed role selection to vertical layout for better readability
- Made required fields more prominent with bold labels

The invitation process now works correctly for all users with proper permissions (admins and managers).